### PR TITLE
Add new feature of retweeting

### DIFF
--- a/packages/twitter-ui/my-app/src/App.tsx
+++ b/packages/twitter-ui/my-app/src/App.tsx
@@ -4,43 +4,8 @@ import "normalize.css";
 
 import TweetsFeed from "./components/TweetsFeed";
 
-const tweets = [
-  {
-    user: {
-      fullName: "Christoper Francisco",
-      username: "@christopher",
-    },
-    message: "I like coding",
-    favoriteCount: 3,
-    replyCount: 2,
-    retweetCount: 1,
-  },
-  {
-    user: {
-      fullName: "Jaun García",
-      username: "@juank",
-    },
-    message: `Her ay 70 TL ücret.
-    Günde 7-8 kere kopma. 
-    3 haftadır her aradığımda "Ekip arkadaşlarımız çalışıyor." yanıtı, sanırım fiber falan döşüyorlar.`,
-    favoriteCount: 3,
-    replyCount: 2,
-    retweetCount: 1,
-  },
-  {
-    user: {
-      fullName: "Daniel Fernando",
-      username: "@dani",
-    },
-    message: "I like coding",
-    favoriteCount: 3,
-    replyCount: 2,
-    retweetCount: 1,
-  },
-];
-
 function App() {
-  return <TweetsFeed tweets={tweets} />;
+  return <TweetsFeed />;
 }
 
 export default App;

--- a/packages/twitter-ui/my-app/src/components/Tweet.tsx
+++ b/packages/twitter-ui/my-app/src/components/Tweet.tsx
@@ -41,11 +41,7 @@ const Tweet: React.FC<TweetProps> = ({
               tweets={tweets}
               setTweets={setTweets}
             />
-            <FavoriteCount
-              tweet={currentTweet}
-              tweets={tweets}
-              setTweets={setTweets}
-            />
+            <FavoriteCount favoriteCount={favoriteCount} />
           </div>
         </div>
       </div>

--- a/packages/twitter-ui/my-app/src/components/Tweet.tsx
+++ b/packages/twitter-ui/my-app/src/components/Tweet.tsx
@@ -2,29 +2,24 @@ import React, { useState } from "react";
 import { ITweet } from "../types/tweet";
 import getUserInitials from "./utils/getUserInitials";
 import ModeCommentOutlinedIcon from "@mui/icons-material/ModeCommentOutlined";
-import FavoriteBorderOutlinedIcon from "@mui/icons-material/FavoriteBorderOutlined";
-import AutorenewIcon from "@mui/icons-material/Autorenew";
 
-export interface TweetProps extends ITweet {}
+import RetweetCount from "./TweetCounts/RetweetCount/RetweetCount";
+import FavoriteCount from "./TweetCounts/FavoriteCount/FavoriteCount";
+
+export interface TweetProps {
+  tweet: ITweet;
+  tweets: ITweet[];
+  setTweets: React.Dispatch<React.SetStateAction<ITweet[]>>;
+}
 
 const Tweet: React.FC<TweetProps> = ({
-  user,
-  favoriteCount,
-  message,
-  replyCount,
-  retweetCount,
+  tweet: currentTweet,
+  tweets,
+  setTweets,
 }) => {
-  const [hasAlreadyBeenFavorited, setHasAlreadyBeenFavorited] =
-    useState<boolean>(false);
-  const [newFavoriteCount, setNewFavoriteCount] = useState(favoriteCount);
+  const { favoriteCount, message, replyCount, retweetCount, user } =
+    currentTweet;
 
-  const handleFavoriteClick = () => () => {
-    setHasAlreadyBeenFavorited((prev) => !prev);
-
-    const calculateNewFavoriteCount = hasAlreadyBeenFavorited ? -1 : 1;
-
-    setNewFavoriteCount((prev) => prev + calculateNewFavoriteCount);
-  };
   return (
     <div data-testid="tweet" className="tweet">
       <div className="tweet__main-container">
@@ -41,22 +36,16 @@ const Tweet: React.FC<TweetProps> = ({
             <span title="reply count" className="tweet__reply-count">
               <ModeCommentOutlinedIcon width={"16px"} /> {replyCount}
             </span>
-            <span title="retweet count" className="tweet__retweet-count">
-              <AutorenewIcon width={"18px"} /> {retweetCount}
-            </span>
-            <span
-              title="favorite count"
-              onClick={handleFavoriteClick()}
-              className="tweet__favorite-count"
-            >
-              <FavoriteBorderOutlinedIcon
-                style={{
-                  fill: hasAlreadyBeenFavorited ? "red" : "",
-                }}
-                width={"18px"}
-              />
-              {newFavoriteCount}
-            </span>
+            <RetweetCount
+              tweet={currentTweet}
+              tweets={tweets}
+              setTweets={setTweets}
+            />
+            <FavoriteCount
+              tweet={currentTweet}
+              tweets={tweets}
+              setTweets={setTweets}
+            />
           </div>
         </div>
       </div>

--- a/packages/twitter-ui/my-app/src/components/TweetCounts/FavoriteCount/FavoriteCount.tsx
+++ b/packages/twitter-ui/my-app/src/components/TweetCounts/FavoriteCount/FavoriteCount.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import type { TweetProps } from "../../Tweet";
+import FavoriteBorderOutlinedIcon from "@mui/icons-material/FavoriteBorderOutlined";
+
+const FavoriteCount: React.FC<TweetProps> = ({ tweet, tweets, setTweets }) => {
+  const { isAlreadyFavorite, favoriteCount } = tweet;
+  const handleFavoriteCount = () => {
+    //This is a little contrived but it should work until we connect to our API and we can perform POST request to favorite
+    //a tweet in this component instance so we canrefactor some of this gibberish
+
+    setTweets((prevTweets) =>
+      prevTweets.map((prevTweet) =>
+        prevTweet.id === tweet.id
+          ? {
+              ...prevTweet,
+              isAlreadyFavorite: !prevTweet.isAlreadyFavorite,
+              favoriteCount:
+                prevTweet.favoriteCount +
+                (prevTweet.isAlreadyFavorite ? -1 : 1),
+            }
+          : prevTweet
+      )
+    );
+    console.log(tweets);
+  };
+
+  return (
+    <span
+      title="favorite count"
+      onClick={() => handleFavoriteCount()}
+      className="tweet__favorite-count"
+    >
+      <FavoriteBorderOutlinedIcon
+        style={{
+          fill: isAlreadyFavorite ? "red" : "",
+        }}
+        width={"18px"}
+      />
+      {favoriteCount}
+    </span>
+  );
+};
+
+export default FavoriteCount;

--- a/packages/twitter-ui/my-app/src/components/TweetCounts/FavoriteCount/FavoriteCount.tsx
+++ b/packages/twitter-ui/my-app/src/components/TweetCounts/FavoriteCount/FavoriteCount.tsx
@@ -1,33 +1,24 @@
-import React from "react";
-import type { TweetProps } from "../../Tweet";
+import React, { useState } from "react";
 import FavoriteBorderOutlinedIcon from "@mui/icons-material/FavoriteBorderOutlined";
+import type { ITweet } from "../../../types/tweet";
 
-const FavoriteCount: React.FC<TweetProps> = ({ tweet, tweets, setTweets }) => {
-  const { isAlreadyFavorite, favoriteCount } = tweet;
-  const handleFavoriteCount = () => {
-    //This is a little contrived but it should work until we connect to our API and we can perform POST request to favorite
-    //a tweet in this component instance so we canrefactor some of this gibberish
+type FavoriteCountProps = Pick<ITweet, "favoriteCount">;
 
-    setTweets((prevTweets) =>
-      prevTweets.map((prevTweet) =>
-        prevTweet.id === tweet.id
-          ? {
-              ...prevTweet,
-              isAlreadyFavorite: !prevTweet.isAlreadyFavorite,
-              favoriteCount:
-                prevTweet.favoriteCount +
-                (prevTweet.isAlreadyFavorite ? -1 : 1),
-            }
-          : prevTweet
-      )
-    );
-    console.log(tweets);
+const FavoriteCount: React.FC<FavoriteCountProps> = ({ favoriteCount }) => {
+  const [isAlreadyFavorite, setIsAlreadyFavorite] = useState<boolean>(false);
+  const [newFavoriteCount, setNewFavoriteCount] = useState(favoriteCount);
+
+  const handleFavoriteClick = () => {
+    setIsAlreadyFavorite((prev) => !prev);
+
+    const calculateNewFavoriteCount = isAlreadyFavorite ? -1 : 1;
+    setNewFavoriteCount((prev) => prev + calculateNewFavoriteCount);
   };
 
   return (
     <span
       title="favorite count"
-      onClick={() => handleFavoriteCount()}
+      onClick={() => handleFavoriteClick()}
       className="tweet__favorite-count"
     >
       <FavoriteBorderOutlinedIcon
@@ -36,7 +27,7 @@ const FavoriteCount: React.FC<TweetProps> = ({ tweet, tweets, setTweets }) => {
         }}
         width={"18px"}
       />
-      {favoriteCount}
+      {newFavoriteCount}
     </span>
   );
 };

--- a/packages/twitter-ui/my-app/src/components/TweetCounts/RetweetCount/RetweetCount.tsx
+++ b/packages/twitter-ui/my-app/src/components/TweetCounts/RetweetCount/RetweetCount.tsx
@@ -1,17 +1,28 @@
-import React from "react";
+import React, { useState } from "react";
 import AutorenewIcon from "@mui/icons-material/Autorenew";
 
 import type { TweetProps } from "../../Tweet";
 import useHandleRetweet from "./useHandleRetweet";
 
 const RetweetCount: React.FC<TweetProps> = ({ tweet, tweets, setTweets }) => {
-  const { retweetCount, isAlreadyRetweeted } = tweet;
+  const { retweetCount } = tweet;
   const { handleRetweet } = useHandleRetweet(tweet, tweets, setTweets);
+
+  const [isAlreadyRetweeted, setIsAlreadyRetweeted] = useState<boolean>(false);
+  const [newRetweetCount, setNewRetweetCount] = useState(retweetCount);
+
+  const handleRetweetCount = () => () => {
+    setIsAlreadyRetweeted((prev) => !prev);
+
+    const calculateNewFavoriteCount = isAlreadyRetweeted ? -1 : 1;
+    setNewRetweetCount((prev) => prev + calculateNewFavoriteCount);
+  };
   return (
     <span
       title="retweet count"
       onClick={() => {
         handleRetweet();
+        handleRetweetCount();
       }}
       className="tweet__retweet-count"
     >
@@ -21,7 +32,7 @@ const RetweetCount: React.FC<TweetProps> = ({ tweet, tweets, setTweets }) => {
           fill: isAlreadyRetweeted ? "green" : "",
         }}
       />{" "}
-      {retweetCount}
+      {newRetweetCount}
     </span>
   );
 };

--- a/packages/twitter-ui/my-app/src/components/TweetCounts/RetweetCount/RetweetCount.tsx
+++ b/packages/twitter-ui/my-app/src/components/TweetCounts/RetweetCount/RetweetCount.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import AutorenewIcon from "@mui/icons-material/Autorenew";
+
+import type { TweetProps } from "../../Tweet";
+import useHandleRetweet from "./useHandleRetweet";
+
+const RetweetCount: React.FC<TweetProps> = ({ tweet, tweets, setTweets }) => {
+  const { retweetCount, isAlreadyRetweeted } = tweet;
+  const { handleRetweet } = useHandleRetweet(tweet, tweets, setTweets);
+  return (
+    <span
+      title="retweet count"
+      onClick={() => {
+        handleRetweet();
+      }}
+      className="tweet__retweet-count"
+    >
+      <AutorenewIcon
+        width={"18px"}
+        style={{
+          fill: isAlreadyRetweeted ? "green" : "",
+        }}
+      />{" "}
+      {retweetCount}
+    </span>
+  );
+};
+
+export default React.memo(RetweetCount);

--- a/packages/twitter-ui/my-app/src/components/TweetCounts/RetweetCount/useHandleRetweet.ts
+++ b/packages/twitter-ui/my-app/src/components/TweetCounts/RetweetCount/useHandleRetweet.ts
@@ -8,11 +8,9 @@ export default function useHandleRetweet(
 ) {
   useEffect(() => {
     localStorage.setItem("tweets", JSON.stringify(tweets));
-    console.log(localStorage.getItem("tweets"));
   }, [tweets]);
 
   const handleRetweet = () => {
-    console.log("this should cause rerender");
     setTweets((prev) => [tweetToRetweet, ...prev]);
   };
 

--- a/packages/twitter-ui/my-app/src/components/TweetCounts/RetweetCount/useHandleRetweet.ts
+++ b/packages/twitter-ui/my-app/src/components/TweetCounts/RetweetCount/useHandleRetweet.ts
@@ -1,0 +1,20 @@
+import { useEffect } from "react";
+import { ITweet } from "../../../types/tweet";
+
+export default function useHandleRetweet(
+  tweetToRetweet: ITweet,
+  tweets: ITweet[],
+  setTweets: React.Dispatch<React.SetStateAction<ITweet[]>>
+) {
+  useEffect(() => {
+    localStorage.setItem("tweets", JSON.stringify(tweets));
+    console.log(localStorage.getItem("tweets"));
+  }, [tweets]);
+
+  const handleRetweet = () => {
+    console.log("this should cause rerender");
+    setTweets((prev) => [tweetToRetweet, ...prev]);
+  };
+
+  return { handleRetweet };
+}

--- a/packages/twitter-ui/my-app/src/components/TweetsFeed.tsx
+++ b/packages/twitter-ui/my-app/src/components/TweetsFeed.tsx
@@ -1,16 +1,76 @@
-import React from "react";
+import React, { useState } from "react";
 import { ITweet } from "../types/tweet";
 import Tweet from "./Tweet";
 
-interface TweetsFeedProps {
-  tweets: ITweet[];
-}
+interface TweetsFeedProps {}
 
-const TweetsFeed: React.FC<TweetsFeedProps> = ({ tweets }) => {
+const tweetsData = [
+  {
+    id: 1,
+    user: {
+      fullName: "Christoper Francisco",
+      username: "@christopher",
+    },
+    message: "I like coding",
+    favoriteCount: 3,
+    replyCount: 2,
+    retweetCount: 1,
+    isAlreadyFavorite: false,
+    isAlreadyRetweeted: false,
+  },
+  {
+    id: 2,
+    user: {
+      fullName: "Jaun García",
+      username: "@juank",
+    },
+    message: `Her ay 70 TL ücret.
+    Günde 7-8 kere kopma. 
+    3 haftadır her aradığımda "Ekip arkadaşlarımız çalışıyor." yanıtı, sanırım fiber falan döşüyorlar.`,
+    favoriteCount: 3,
+    replyCount: 2,
+    retweetCount: 1,
+    isAlreadyFavorite: false,
+    isAlreadyRetweeted: false,
+  },
+
+  {
+    id: 3,
+    user: {
+      fullName: "Daniel Fernando",
+      username: "@dani",
+    },
+    message: "I like coding",
+    favoriteCount: 3,
+    replyCount: 2,
+    retweetCount: 1,
+    isAlreadyFavorite: false,
+    isAlreadyRetweeted: false,
+  },
+];
+
+const TweetsFeed: React.FC<TweetsFeedProps> = ({}) => {
+  const [tweets, setTweets] = useState<ITweet[]>(() => {
+    const inMemoryTweets = localStorage.getItem("tweets");
+    const initialValue = inMemoryTweets
+      ? JSON.parse(inMemoryTweets)
+      : tweetsData;
+    console.log("this is in memor", initialValue);
+    return initialValue;
+  });
+
+  console.log(tweets);
   return (
     <div>
       {tweets.map((tweet, idx) => {
-        return <Tweet key={idx} {...tweet} />;
+        return (
+          <Tweet
+            tweet={tweet}
+            tweets={tweets}
+            setTweets={setTweets}
+            key={idx}
+          />
+        );
       })}
     </div>
   );

--- a/packages/twitter-ui/my-app/src/components/TweetsFeed.tsx
+++ b/packages/twitter-ui/my-app/src/components/TweetsFeed.tsx
@@ -55,7 +55,6 @@ const TweetsFeed: React.FC<TweetsFeedProps> = ({}) => {
     const initialValue = inMemoryTweets
       ? JSON.parse(inMemoryTweets)
       : tweetsData;
-    console.log("this is in memor", initialValue);
     return initialValue;
   });
 

--- a/packages/twitter-ui/my-app/src/components/TweetsFeed.tsx
+++ b/packages/twitter-ui/my-app/src/components/TweetsFeed.tsx
@@ -58,7 +58,6 @@ const TweetsFeed: React.FC<TweetsFeedProps> = ({}) => {
     return initialValue;
   });
 
-  console.log(tweets);
   return (
     <div>
       {tweets.map((tweet, idx) => {

--- a/packages/twitter-ui/my-app/src/components/__tests__/Tweet.tsx
+++ b/packages/twitter-ui/my-app/src/components/__tests__/Tweet.tsx
@@ -4,15 +4,37 @@ import getUserInitials from "../utils/getUserInitials";
 import user from "@testing-library/user-event";
 
 const props: TweetProps = {
-  user: {
-    fullName: "Christoper Francisco",
-    username: "@christopher",
+  tweet: {
+    id: 1,
+    user: {
+      fullName: "Christoper Francisco",
+      username: "@christopher",
+    },
+    message: "I like coding",
+    favoriteCount: 3,
+    replyCount: 2,
+    retweetCount: 1,
+    isAlreadyFavorite: false,
+    isAlreadyRetweeted: true,
   },
-  message: "I like coding",
-  favoriteCount: 3,
-  replyCount: 2,
-  retweetCount: 1,
+  tweets: [
+    {
+      id: 1,
+      user: {
+        fullName: "Christoper Francisco",
+        username: "@christopher",
+      },
+      message: "I like coding",
+      favoriteCount: 3,
+      replyCount: 2,
+      retweetCount: 1,
+      isAlreadyFavorite: false,
+      isAlreadyRetweeted: true,
+    },
+  ],
+  setTweets: jest.fn(),
 };
+
 test("should render a tweet with mock data", () => {
   render(<Tweet {...props} />);
   //counts
@@ -21,16 +43,16 @@ test("should render a tweet with mock data", () => {
   expect(screen.getByTitle(/retweet count/)).toBeInTheDocument();
 
   //user info
-  expect(screen.getByText(props.user.username)).toBeInTheDocument();
+  expect(screen.getByText(props.tweet.user.username)).toBeInTheDocument();
   expect(screen.getByRole("heading", { level: 2 })).toBeInTheDocument();
 
-  expect(screen.getByText(props.message)).toBeInTheDocument();
+  expect(screen.getByText(props.tweet.message)).toBeInTheDocument();
 
   //This acts as our user image for now.
   expect(screen.getByRole("figure")).toBeInTheDocument();
 
   expect(
-    screen.getByText(getUserInitials(props.user.fullName))
+    screen.getByText(getUserInitials(props.tweet.user.fullName))
   ).toBeInTheDocument();
 });
 
@@ -44,5 +66,5 @@ test("should aument favorite count", () => {
 
   user.click(favoriteCountButton);
 
-  expect(favoriteCountButton.textContent).toBe("3");
+  expect(favoriteCountButton.textContent).toBe(/3/);
 });

--- a/packages/twitter-ui/my-app/src/components/__tests__/Tweet.tsx
+++ b/packages/twitter-ui/my-app/src/components/__tests__/Tweet.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import Tweet, { TweetProps } from "../Tweet";
 import getUserInitials from "../utils/getUserInitials";
 import user from "@testing-library/user-event";
@@ -14,8 +14,6 @@ const props: TweetProps = {
     favoriteCount: 3,
     replyCount: 2,
     retweetCount: 1,
-    isAlreadyFavorite: false,
-    isAlreadyRetweeted: true,
   },
   tweets: [
     {
@@ -28,8 +26,6 @@ const props: TweetProps = {
       favoriteCount: 3,
       replyCount: 2,
       retweetCount: 1,
-      isAlreadyFavorite: false,
-      isAlreadyRetweeted: true,
     },
   ],
   setTweets: jest.fn(),
@@ -56,15 +52,15 @@ test("should render a tweet with mock data", () => {
   ).toBeInTheDocument();
 });
 
-test("should aument favorite count", () => {
+test("should aument and decrease favorite count", async () => {
   render(<Tweet {...props} />);
 
   const favoriteCountButton = screen.getByTitle(/favorite count/);
   user.click(favoriteCountButton);
 
-  expect(favoriteCountButton.textContent).toMatch(/4/);
+  await waitFor(() => expect(favoriteCountButton.textContent).toMatch(/4/));
 
   user.click(favoriteCountButton);
 
-  expect(favoriteCountButton.textContent).toBe(/3/);
+  expect(favoriteCountButton.textContent).toMatch(/3/);
 });

--- a/packages/twitter-ui/my-app/src/components/__tests__/TweetsFeed.tsx
+++ b/packages/twitter-ui/my-app/src/components/__tests__/TweetsFeed.tsx
@@ -1,42 +1,22 @@
 import { render, screen } from "@testing-library/react";
 import TweetsFeed from "../TweetsFeed";
+import user from "@testing-library/user-event";
 
 test("should render a list of tweets", () => {
-  const props = [
-    {
-      user: {
-        fullName: "Christoper Francisco",
-        username: "christopher",
-      },
-      message: "I like coding",
-      favoriteCount: 3,
-      replyCount: 2,
-      retweetCount: 1,
-    },
-    {
-      user: {
-        fullName: "Jaun García",
-        username: "juank",
-      },
-      message: "I like coding",
-      favoriteCount: 3,
-      replyCount: 2,
-      retweetCount: 1,
-    },
-    {
-      user: {
-        fullName: "Daniel Fernando",
-        username: "dani",
-      },
-      message: "I like coding",
-      favoriteCount: 3,
-      replyCount: 2,
-      retweetCount: 1,
-    },
-  ];
-  render(<TweetsFeed tweets={props} />);
-
+  render(<TweetsFeed />);
   const tweets = screen.getAllByTestId("tweet");
 
   expect(tweets).toHaveLength(3);
+});
+
+test("should retweet a tweet", () => {
+  render(<TweetsFeed />);
+
+  const toRetweet = screen.getAllByTitle(/retweet count/)[0];
+
+  user.click(toRetweet);
+
+  const tweets = screen.getAllByTestId("tweet");
+
+  expect(tweets).toHaveLength(4);
 });

--- a/packages/twitter-ui/my-app/src/types/tweet.ts
+++ b/packages/twitter-ui/my-app/src/types/tweet.ts
@@ -1,9 +1,12 @@
 import User from "./user";
 
 export interface ITweet {
+  id: number;
   user: User;
   message: string;
   favoriteCount: number;
   replyCount: number;
   retweetCount: number;
+  isAlreadyFavorite: boolean;
+  isAlreadyRetweeted: boolean;
 }

--- a/packages/twitter-ui/my-app/src/types/tweet.ts
+++ b/packages/twitter-ui/my-app/src/types/tweet.ts
@@ -7,6 +7,4 @@ export interface ITweet {
   favoriteCount: number;
   replyCount: number;
   retweetCount: number;
-  isAlreadyFavorite: boolean;
-  isAlreadyRetweeted: boolean;
 }


### PR DESCRIPTION
In this PR: 
* We moved all our UI and logic responsible for handling our different tweet counts into its own modules and functions (following Single Responsibility Principle).
* Created a new feature of "retweeting", adding the retweeted to to the top of our feed.
* 
Considerations:

Right now we have very serious props drilling in our components, in the future we will solve this with a state management library or, if we use GraphQL, with cache updating.

This resolves: #6 