### PR TITLE
Add tweet type to tweet model

### DIFF
--- a/packages/twitter-ui/my-app/src/App.scss
+++ b/packages/twitter-ui/my-app/src/App.scss
@@ -97,6 +97,21 @@ body {
       }
     }
 
+    &__retweet-message {
+        color: $gray;
+        font-size: 14px;
+        font-weight: 600;
+        grid-column: 2 / 2;
+    }
+
+    &__retweet-message-icon {
+        color: $gray;
+        width: 22px !important;
+        margin-left: 30px;
+        margin-top: -5px;
+        margin-bottom: 5px;
+    }
+
 }
 
 .tweet-text-area {

--- a/packages/twitter-ui/my-app/src/components/Tweet.tsx
+++ b/packages/twitter-ui/my-app/src/components/Tweet.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { ITweet } from "../types/tweet";
 import getUserInitials from "./utils/getUserInitials";
 import ModeCommentOutlinedIcon from "@mui/icons-material/ModeCommentOutlined";
-
+import AutorenewIcon from "@mui/icons-material/Autorenew";
 import RetweetCount from "./TweetCounts/RetweetCount/RetweetCount";
 import FavoriteCount from "./TweetCounts/FavoriteCount/FavoriteCount";
 
@@ -11,11 +11,17 @@ export interface TweetProps {
 }
 
 const Tweet: React.FC<TweetProps> = ({ tweet }) => {
-  const { message, replyCount, user } = tweet;
+  const { message, replyCount, user, type } = tweet;
 
   return (
     <div data-testid="tweet" className="tweet">
       <div className="tweet__main-container">
+        {type === "retweet" && (
+          <>
+            <AutorenewIcon className="tweet__retweet-message-icon" />
+            <span className="tweet__retweet-message">You Retweeted</span>
+          </>
+        )}
         <figure> {getUserInitials(user.fullName)} </figure>
         <div>
           <div className="tweet__user-container">

--- a/packages/twitter-ui/my-app/src/components/TweetTextArea.tsx
+++ b/packages/twitter-ui/my-app/src/components/TweetTextArea.tsx
@@ -11,7 +11,8 @@ const newTweetMarkup = {
   favoriteCount: 0,
   retweetCount: 0,
   replyCount: 0,
-};
+  type: "default",
+} as const;
 
 const TweetTextArea: React.FC = () => {
   const [tweetText, setTweetText] = useState("");

--- a/packages/twitter-ui/my-app/src/hooks/useTweets.ts
+++ b/packages/twitter-ui/my-app/src/hooks/useTweets.ts
@@ -35,7 +35,7 @@ export function useTweets() {
   };
 
   const addRetweet = (tweet: ITweet) => {
-    setTweets([tweet, ...tweets]);
+    setTweets([{ ...tweet, id: tweet.id, type: "retweet" }, ...tweets]);
   };
   return {
     tweets,

--- a/packages/twitter-ui/my-app/src/tweetsData.ts
+++ b/packages/twitter-ui/my-app/src/tweetsData.ts
@@ -11,6 +11,7 @@ export const tweetsData: ITweet[] = [
     favoriteCount: 3,
     replyCount: 2,
     retweetCount: 1,
+    type: "default",
   },
   {
     id: 2,
@@ -24,6 +25,7 @@ export const tweetsData: ITweet[] = [
     favoriteCount: 3,
     replyCount: 2,
     retweetCount: 1,
+    type: "default",
   },
 
   {
@@ -36,5 +38,6 @@ export const tweetsData: ITweet[] = [
     favoriteCount: 3,
     replyCount: 2,
     retweetCount: 1,
+    type: "default",
   },
 ];

--- a/packages/twitter-ui/my-app/src/types/tweet.ts
+++ b/packages/twitter-ui/my-app/src/types/tweet.ts
@@ -7,4 +7,5 @@ export interface ITweet {
   favoriteCount: number;
   replyCount: number;
   retweetCount: number;
+  type: "default" | "retweet";
 }


### PR DESCRIPTION
In this PR:  
* Added a new tweet type to our model, it can be of type _default_ or _tweet_
* Updated our addRetweet method in the useTweets hook, now it makes a shallow copy of our tweet change its type and holds the same id of our original tweet.
*  Updated our visuals so it can be known that the tweet is a retweet. (For now we will display a simple message, later on when the tweet can be quoted, the quoted will be shown instead of our message :P)

This resolves: #28 and is dependent on #31 