### PR TITLE
Add a new modal to add text to a retweet

### DIFF
--- a/packages/twitter-ui/package.json
+++ b/packages/twitter-ui/package.json
@@ -19,6 +19,7 @@
     "react-dom": "^18.2.0",
     "react-modal": "^3.15.1",
     "react-scripts": "5.0.1",
+    "react-textarea-autosize": "^8.3.4",
     "typescript": "^4.4.2",
     "web-vitals": "^2.1.0"
   },

--- a/packages/twitter-ui/package.json
+++ b/packages/twitter-ui/package.json
@@ -17,6 +17,7 @@
     "normalize.css": "^8.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-modal": "^3.15.1",
     "react-scripts": "5.0.1",
     "typescript": "^4.4.2",
     "web-vitals": "^2.1.0"
@@ -68,6 +69,7 @@
     "@storybook/preset-create-react-app": "^4.1.2",
     "@storybook/react": "^6.5.9",
     "@storybook/testing-library": "^0.0.13",
+    "@types/react-modal": "^3.13.1",
     "babel-plugin-named-exports-order": "^0.0.2",
     "prop-types": "^15.8.1",
     "sass": "^1.53.0",

--- a/packages/twitter-ui/src/App.scss
+++ b/packages/twitter-ui/src/App.scss
@@ -61,19 +61,7 @@ body {
         color: $white
     }
 
-    figure {
-        color: $white;
-        background-color: gray;
-        width: 50px;
-        grid-column: 1/1;
-        height: 50px;
-        margin: 0;
-        margin-right: 10px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        border-radius: 50%;
-    }
+   
 
 
     &__count-container {
@@ -126,19 +114,7 @@ body {
         column-gap: 12px;
     }
 
-    figure {
-        color: $white;
-        background-color: gray;
-        width: 40px;
-        grid-column: 1/1;
-        height: 40px;
-        margin: 0;
-        margin-right: 10px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        border-radius: 50%;
-    }
+    
 
     &__form-container {
         position: relative;
@@ -192,4 +168,36 @@ body {
     line-height: 19px;
     align-self: flex-end;
     display: inline-block;
+}
+
+.user-image {
+    
+        color: $white;
+        background-color: gray;
+        grid-column: 1/1;
+        height: 50px;
+        margin: 0;
+        margin-right: 10px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 50%;
+    
+
+        &--small {
+            width: 30px;
+            font-size: 10px;
+            height: 30px;
+        }
+
+        &--medium {
+            width: 40px;
+            height: 40px;
+            font-size: 12px;
+        }
+
+        &--large {
+            width: 50px;
+            height: 50px;
+        }
 }

--- a/packages/twitter-ui/src/App.scss
+++ b/packages/twitter-ui/src/App.scss
@@ -5,10 +5,48 @@ $white: #FFFFFF;
 
 body {
     font-family: 'Source Sans Pro';
-
+    
 }
 
 
+
+.tweet-preview {
+    background-color: $black;
+    display:flex;
+    padding: 10px;
+    flex-direction: column;
+    max-width: 100%;
+    margin-bottom: 15px;
+     border: 0.5px solid $gray;
+     border-radius: 20px;
+
+    &__user-container {
+       display: flex;
+
+    }
+    &__username {
+        color: $gray;
+        margin-left: 2px;
+        font-size: 10px;
+        
+        margin-top: 2px;
+    }
+
+    &__full-name  {
+        color: $white;
+        margin: 0;
+        font-size: .8rem;
+        font-weight: 700;
+        margin-right: 5px;
+    }
+
+    &__message {
+        color: white;
+        font-size: 1rem;
+        margin-top: 5px;
+        white-space: pre-line;
+    }
+}
 
 .tweet {
     background-color: $black;
@@ -50,11 +88,12 @@ body {
     &__message {
         grid-column: 2/2;
         color: white;
-        font-size: 12px;
+        font-size: 1rem;
         margin-top: 5px;
         margin-bottom: 12px;
         grid-row-start: 2;
         white-space: pre-line;
+        font-weight: 400;
     }
 
     &__body {
@@ -200,4 +239,16 @@ body {
             width: 50px;
             height: 50px;
         }
+}
+
+.modal {
+    position: absolute;
+    top: 40px;
+    left: 40px;
+    right: 40px;
+    bottom: 40px;
+    width: 40%;
+    border-radius: 20px;
+    padding: 20px;
+    background-color: $black;
 }

--- a/packages/twitter-ui/src/App.scss
+++ b/packages/twitter-ui/src/App.scss
@@ -1,6 +1,8 @@
 $primary-color: #1DA1F2;
 $black: #000000;
 $gray: #8899A6;
+$black-gray: #2F3336;
+
 $white: #FFFFFF;
 
 body {
@@ -13,11 +15,11 @@ body {
 .tweet-preview {
     background-color: $black;
     display:flex;
-    padding: 10px;
+    padding: 14px;
     flex-direction: column;
     max-width: 100%;
     margin-bottom: 15px;
-     border: 0.5px solid $gray;
+     border: 0.4px solid $black-gray;
      border-radius: 20px;
 
     &__user-container {
@@ -201,9 +203,9 @@ body {
     
 
         &--small {
-            width: 30px;
+            width: 15px;
             font-size: 10px;
-            height: 30px;
+            height: 15px;
         }
 
         &--medium {
@@ -228,7 +230,7 @@ body {
     bottom: 40px;
     display: inline-block;
     border-radius: 20px;
-    padding: 20px;
+    padding: 5px;
     background-color: $black;
 }
 
@@ -238,7 +240,8 @@ body {
     outline: none;
     font-size: 19px;
     line-height: 23px;
-    color: $gray;
+    color: $white;
+    font-weight: 600;
 
     &__container {
         position: relative;

--- a/packages/twitter-ui/src/App.scss
+++ b/packages/twitter-ui/src/App.scss
@@ -141,7 +141,7 @@ body {
 
 }
 
-.tweet-text-area {
+.new-tweet-form {
     min-width: 300px;  
     max-width: 600px;
     background-color: $black;
@@ -163,51 +163,28 @@ body {
     }
 
     
-    &__text-box {
-        background-color: $black;
-        border: none;
-        outline: none;
-        font-size: 19px;
-        line-height: 23px;
-        color: $gray;
-        &:focus + label {
-            opacity: 0;
-            top: -10px;
-            display: none;
-        }
-     
-        &:valid + label {
-            opacity: 0;
-            top: -10px;
-            display: none;
-        
-        }
-
-        &__label {
-            font-size: 19px; 
-            line-height: 19px;
-            color: $gray;
-            margin-left: 2px;
-            position: absolute;
-            margin-top:4px;
-        }
-
-       
-    }
+  
 }
 
-.primary-button {
+
+.button {
     font-weight: 700;
-    color: $white;
     padding: 10px 31px;
-    background-color: $primary-color;
     text-decoration: none;
-    text-align: center; 
-    border-radius: 52px;
+    text-align: center;     
     line-height: 19px;
-    align-self: flex-end;
     display: inline-block;
+    border-radius: 52px;
+
+    &--primary {
+    color: $white;
+    background-color: $primary-color;
+    }
+
+
+
 }
+
 
 .user-image {
     
@@ -245,10 +222,49 @@ body {
     position: absolute;
     top: 40px;
     left: 40px;
+    width: min-content;
+    height: min-content;
     right: 40px;
     bottom: 40px;
-    width: 40%;
+    display: inline-block;
     border-radius: 20px;
     padding: 20px;
     background-color: $black;
+}
+
+.text-box {
+    background-color: $black;
+    border: none;
+    outline: none;
+    font-size: 19px;
+    line-height: 23px;
+    color: $gray;
+
+    &__container {
+        position: relative;
+    }
+    &:focus + label {
+        opacity: 0;
+        top: -10px;
+        display: none;
+    }
+ 
+    &:valid + label {
+        opacity: 0;
+        top: -10px;
+        display: none;
+    
+    }
+
+    &__label {
+        font-size: 19px; 
+        line-height: 19px;
+        color: $gray;
+        margin-left: 2px;
+        position: absolute;
+        margin-top:4px;
+        left: 0px;
+    }
+
+   
 }

--- a/packages/twitter-ui/src/App.tsx
+++ b/packages/twitter-ui/src/App.tsx
@@ -4,12 +4,12 @@ import "normalize.css";
 
 import { TweetsFeed } from "./components/TweetsFeed";
 import { TweetContextProvider } from "./context/TweetContext";
-import { TweetTextArea } from "./components/TweetTextArea";
+import { NewTweetForm } from "./components/Form";
 
 function App() {
   return (
     <TweetContextProvider>
-      <TweetTextArea />
+      <NewTweetForm />
       <TweetsFeed />
     </TweetContextProvider>
   );

--- a/packages/twitter-ui/src/components/Button/Button.stories.tsx
+++ b/packages/twitter-ui/src/components/Button/Button.stories.tsx
@@ -1,0 +1,17 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import "../../App.scss";
+import { Button } from ".";
+
+export default {
+  title: "Form",
+  component: Button,
+  argTypes: { onClick: { action: "You just clicked the button!" } },
+} as ComponentMeta<typeof Button>;
+
+const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />;
+
+export const NormalButton = Template.bind({});
+
+NormalButton.args = {
+  buttonType: "primary",
+};

--- a/packages/twitter-ui/src/components/Button/Button.tsx
+++ b/packages/twitter-ui/src/components/Button/Button.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
+  type: "primary";
+  children: React.ReactNode;
+}
+
+const Button: React.FC<ButtonProps> = ({
+  type = "primary",
+  children,
+  ...props
+}) => {
+  return (
+    <button type="submit" className={`button button--${type}`} {...props}>
+      {children}
+    </button>
+  );
+};
+
+export default Button;

--- a/packages/twitter-ui/src/components/Button/Button.tsx
+++ b/packages/twitter-ui/src/components/Button/Button.tsx
@@ -1,17 +1,17 @@
 import React from "react";
 
-interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
-  type: "primary";
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  buttonType: "primary";
   children: React.ReactNode;
 }
 
 const Button: React.FC<ButtonProps> = ({
-  type = "primary",
+  buttonType = "primary",
   children,
   ...props
 }) => {
   return (
-    <button type="submit" className={`button button--${type}`} {...props}>
+    <button className={`button button--${buttonType}`} {...props}>
       {children}
     </button>
   );

--- a/packages/twitter-ui/src/components/Button/index.ts
+++ b/packages/twitter-ui/src/components/Button/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Button";

--- a/packages/twitter-ui/src/components/Button/index.ts
+++ b/packages/twitter-ui/src/components/Button/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./Button";
+export { default as Button } from "./Button";

--- a/packages/twitter-ui/src/components/Form/NewTweetForm.stories.tsx
+++ b/packages/twitter-ui/src/components/Form/NewTweetForm.stories.tsx
@@ -1,0 +1,15 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import "../../App.scss";
+import { NewTweetForm } from "../Form";
+
+export default {
+  title: "Form",
+  component: NewTweetForm,
+  argTypes: { onClick: { action: "You just favorited this tweet!" } },
+} as ComponentMeta<typeof NewTweetForm>;
+
+const Template: ComponentStory<typeof NewTweetForm> = (args) => (
+  <NewTweetForm {...args} />
+);
+
+export const NormalNewTweetForm = Template.bind({});

--- a/packages/twitter-ui/src/components/Form/NewTweetForm.stories.tsx
+++ b/packages/twitter-ui/src/components/Form/NewTweetForm.stories.tsx
@@ -5,7 +5,6 @@ import { NewTweetForm } from "../Form";
 export default {
   title: "Form",
   component: NewTweetForm,
-  argTypes: { onClick: { action: "You just favorited this tweet!" } },
 } as ComponentMeta<typeof NewTweetForm>;
 
 const Template: ComponentStory<typeof NewTweetForm> = (args) => (

--- a/packages/twitter-ui/src/components/Form/NewTweetForm.tsx
+++ b/packages/twitter-ui/src/components/Form/NewTweetForm.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import getUserInitials from "../../utils/getUserInitials";
+import { useState } from "react";
+import { useTweets } from "../../hooks/useTweets";
+import { UserImage } from "../UserImage";
+import TweetTextArea from "../TweetTextArea";
+import Button from "../Button";
+
+const newTweetMarkup = {
+  user: {
+    fullName: "Christopher Francisco",
+    username: "@christopher",
+  },
+  favoriteCount: 0,
+  retweetCount: 0,
+  replyCount: 0,
+  type: "default",
+} as const;
+
+const NewTweetForm: React.FC = () => {
+  const [tweetText, setTweetText] = useState("");
+  const { tweets, addTweet } = useTweets();
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setTweetText(e.target.value);
+  };
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    addTweet({
+      ...newTweetMarkup,
+      id: tweets.length + 1,
+      message: tweetText,
+    });
+    cleanAfterTweet();
+  };
+
+  const cleanAfterTweet = () => {
+    setTweetText("");
+  };
+
+  return (
+    <div className="new-tweet-form">
+      <div className="new-tweet-form__main-container">
+        <UserImage size="medium">
+          {getUserInitials(newTweetMarkup.user.fullName)}
+        </UserImage>
+        <form
+          className="new-tweet-form__form-container"
+          onSubmit={handleSubmit}
+        >
+          <TweetTextArea
+            name="new-tweet-form"
+            value={tweetText}
+            label="What are you thinking today?"
+            handleChange={handleChange}
+          />
+
+          <Button type="primary" style={{ alignSelf: "flex-end" }}>
+            Tweet{" "}
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default NewTweetForm;

--- a/packages/twitter-ui/src/components/Form/NewTweetForm.tsx
+++ b/packages/twitter-ui/src/components/Form/NewTweetForm.tsx
@@ -4,9 +4,9 @@ import { useState } from "react";
 import { useTweets } from "../../hooks/useTweets";
 import { UserImage } from "../UserImage";
 import TweetTextArea from "../TweetTextArea";
-import Button from "../Button";
+import { Button } from "../Button";
 
-const newTweetMarkup = {
+export const newTweetMarkup = {
   user: {
     fullName: "Christopher Francisco",
     username: "@christopher",
@@ -55,8 +55,12 @@ const NewTweetForm: React.FC = () => {
             label="What are you thinking today?"
             handleChange={handleChange}
           />
-
-          <Button type="primary" style={{ alignSelf: "flex-end" }}>
+          <br />
+          <Button
+            buttonType="primary"
+            type="submit"
+            style={{ alignSelf: "flex-end" }}
+          >
             Tweet{" "}
           </Button>
         </form>

--- a/packages/twitter-ui/src/components/Form/RetweetForm.tsx
+++ b/packages/twitter-ui/src/components/Form/RetweetForm.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from "react";
+import { useTweets } from "../../hooks/useTweets";
+import { ITweet } from "../../types/tweet";
+import getUserInitials from "../../utils/getUserInitials";
+import { Button } from "../Button";
+import { TweetPreview } from "../Tweet";
+import TweetTextArea from "../TweetTextArea";
+import { UserImage } from "../UserImage";
+import { newTweetMarkup } from "./NewTweetForm";
+
+interface RetweetFormProps {
+  tweet: ITweet;
+}
+const RetweetForm: React.FC<RetweetFormProps> = ({ tweet }) => {
+  const [retweetText, setRetweetText] = useState("");
+  const { addRetweet } = useTweets();
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setRetweetText(e.target.value);
+  };
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (retweetText) {
+      addRetweet({
+        ...tweet,
+        retweet: retweetText,
+      });
+      return;
+    }
+    addRetweet(tweet);
+  };
+
+  return (
+    <div className="new-tweet-form__main-container">
+      <UserImage size="large">
+        {getUserInitials(newTweetMarkup.user.fullName)}
+      </UserImage>
+      <form className="new-tweet-form__form-container" onSubmit={handleSubmit}>
+        <TweetTextArea
+          name="new-tweet-form"
+          value={retweetText}
+          minRows={1}
+          label="Add a comment"
+          handleChange={handleChange}
+        />
+        <TweetPreview tweet={tweet} />
+        <Button
+          type="submit"
+          buttonType="primary"
+          style={{ alignSelf: "flex-end" }}
+        >
+          Tweet{" "}
+        </Button>
+      </form>
+    </div>
+  );
+};
+
+export default RetweetForm;

--- a/packages/twitter-ui/src/components/Form/index.ts
+++ b/packages/twitter-ui/src/components/Form/index.ts
@@ -1,1 +1,2 @@
 export { default as NewTweetForm } from "./NewTweetForm";
+export { default as RetweetForm } from "./RetweetForm";

--- a/packages/twitter-ui/src/components/Form/index.ts
+++ b/packages/twitter-ui/src/components/Form/index.ts
@@ -1,0 +1,1 @@
+export { default as NewTweetForm } from "./NewTweetForm";

--- a/packages/twitter-ui/src/components/Modal/Modal.tsx
+++ b/packages/twitter-ui/src/components/Modal/Modal.tsx
@@ -1,0 +1,24 @@
+import React, { useState } from "react";
+import ReactModal from "react-modal";
+
+ReactModal.setAppElement("#root");
+interface ModalProps {
+  // isOpen: boolean;
+  // setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  children: React.ReactNode;
+}
+
+const Modal: React.FC<ModalProps> = ({ children }) => {
+  const [isOpen, setIsOpen] = useState(true);
+  return (
+    <ReactModal
+      className="modal"
+      isOpen={isOpen}
+      onRequestClose={() => setIsOpen(false)}
+    >
+      {children}
+    </ReactModal>
+  );
+};
+
+export default Modal;

--- a/packages/twitter-ui/src/components/Modal/Modal.tsx
+++ b/packages/twitter-ui/src/components/Modal/Modal.tsx
@@ -1,15 +1,14 @@
-import React, { useState } from "react";
+import React from "react";
 import ReactModal from "react-modal";
 
 ReactModal.setAppElement("#root");
 interface ModalProps {
-  // isOpen: boolean;
-  // setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  isOpen: boolean;
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
   children: React.ReactNode;
 }
 
-const Modal: React.FC<ModalProps> = ({ children }) => {
-  const [isOpen, setIsOpen] = useState(true);
+const Modal: React.FC<ModalProps> = ({ children, isOpen, setIsOpen }) => {
   return (
     <ReactModal
       className="modal"

--- a/packages/twitter-ui/src/components/Modal/RetweetModal.stories.tsx
+++ b/packages/twitter-ui/src/components/Modal/RetweetModal.stories.tsx
@@ -1,10 +1,10 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { Modal } from ".";
 import "../../App.scss";
-import { TweetTextArea } from "../TweetTextArea";
+import { NewTweetForm } from "../Form";
 
 export default {
-  title: "Tweets Buttons",
+  title: "Modals",
   component: Modal,
   argTypes: { onClick: { action: "You just favorited this tweet!" } },
 } as ComponentMeta<typeof Modal>;
@@ -14,5 +14,5 @@ const Template: ComponentStory<typeof Modal> = (args) => <Modal {...args} />;
 export const NormalModal = Template.bind({});
 
 NormalModal.args = {
-  children: <TweetTextArea></TweetTextArea>,
+  children: <NewTweetForm />,
 };

--- a/packages/twitter-ui/src/components/Modal/RetweetModal.stories.tsx
+++ b/packages/twitter-ui/src/components/Modal/RetweetModal.stories.tsx
@@ -1,0 +1,18 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { Modal } from ".";
+import "../../App.scss";
+import { TweetTextArea } from "../TweetTextArea";
+
+export default {
+  title: "Tweets Buttons",
+  component: Modal,
+  argTypes: { onClick: { action: "You just favorited this tweet!" } },
+} as ComponentMeta<typeof Modal>;
+
+const Template: ComponentStory<typeof Modal> = (args) => <Modal {...args} />;
+
+export const NormalModal = Template.bind({});
+
+NormalModal.args = {
+  children: <TweetTextArea></TweetTextArea>,
+};

--- a/packages/twitter-ui/src/components/Modal/RetweetModal.stories.tsx
+++ b/packages/twitter-ui/src/components/Modal/RetweetModal.stories.tsx
@@ -1,18 +1,30 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { Modal } from ".";
 import "../../App.scss";
-import { NewTweetForm } from "../Form";
+import { RetweetModal } from "./";
 
 export default {
   title: "Modals",
-  component: Modal,
-  argTypes: { onClick: { action: "You just favorited this tweet!" } },
+  component: RetweetModal,
 } as ComponentMeta<typeof Modal>;
 
-const Template: ComponentStory<typeof Modal> = (args) => <Modal {...args} />;
+const Template: ComponentStory<typeof RetweetModal> = (args) => (
+  <RetweetModal {...args} />
+);
 
-export const NormalModal = Template.bind({});
+export const RetweetNormalModal = Template.bind({});
 
-NormalModal.args = {
-  children: <NewTweetForm />,
+RetweetNormalModal.args = {
+  tweet: {
+    id: 1,
+    user: {
+      fullName: "Christoper Francisco",
+      username: "@christopher",
+    },
+    message: "I like coding",
+    favoriteCount: 3,
+    replyCount: 2,
+    retweetCount: 1,
+    type: "retweet",
+  },
 };

--- a/packages/twitter-ui/src/components/Modal/RetweetModal.tsx
+++ b/packages/twitter-ui/src/components/Modal/RetweetModal.tsx
@@ -1,0 +1,24 @@
+import { Modal } from ".";
+import React from "react";
+import { ITweet } from "../../types/tweet";
+import { RetweetForm } from "../Form";
+
+interface RetweetModalProps {
+  tweet: ITweet;
+  isOpen: boolean;
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const RetweetModal: React.FC<RetweetModalProps> = ({
+  tweet,
+  isOpen,
+  setIsOpen,
+}) => {
+  return (
+    <Modal isOpen={isOpen} setIsOpen={setIsOpen}>
+      <RetweetForm tweet={tweet} />
+    </Modal>
+  );
+};
+
+export default RetweetModal;

--- a/packages/twitter-ui/src/components/Modal/index.ts
+++ b/packages/twitter-ui/src/components/Modal/index.ts
@@ -1,0 +1,1 @@
+export { default as Modal } from "./Modal";

--- a/packages/twitter-ui/src/components/Modal/index.ts
+++ b/packages/twitter-ui/src/components/Modal/index.ts
@@ -1,1 +1,2 @@
 export { default as Modal } from "./Modal";
+export { default as RetweetModal } from "./RetweetModal";

--- a/packages/twitter-ui/src/components/Tweet/Tweet.tsx
+++ b/packages/twitter-ui/src/components/Tweet/Tweet.tsx
@@ -5,6 +5,7 @@ import ModeCommentOutlinedIcon from "@mui/icons-material/ModeCommentOutlined";
 import AutorenewIcon from "@mui/icons-material/Autorenew";
 import { RetweetButton } from "../TweetButtons/RetweetButton";
 import { FavoriteButton } from "../TweetButtons/FavoriteButton";
+import { UserImage } from "../UserImage";
 
 export interface TweetProps {
   tweet: ITweet;
@@ -22,7 +23,7 @@ const Tweet: React.FC<TweetProps> = ({ tweet }) => {
             <span className="tweet__retweet-message">You Retweeted</span>
           </>
         )}
-        <figure> {getUserInitials(user.fullName)} </figure>
+        <UserImage size="large"> {getUserInitials(user.fullName)} </UserImage>
         <div>
           <div className="tweet__user-container">
             <h2 className="tweet__full-name"> {user.fullName} </h2>

--- a/packages/twitter-ui/src/components/Tweet/Tweet.tsx
+++ b/packages/twitter-ui/src/components/Tweet/Tweet.tsx
@@ -13,12 +13,12 @@ export interface TweetProps {
 }
 
 const Tweet: React.FC<TweetProps> = ({ tweet }) => {
-  const { id, favoriteCount, message, replyCount, user, type } = tweet;
+  const { id, favoriteCount, message, replyCount, user, type, retweet } = tweet;
 
   return (
     <div data-testid="tweet" className="tweet">
       <div className="tweet__main-container">
-        {type === "retweet" && (
+        {type === "retweet" && !retweet && (
           <>
             <AutorenewIcon className="tweet__retweet-message-icon" />
             <span className="tweet__retweet-message">You Retweeted</span>
@@ -31,8 +31,8 @@ const Tweet: React.FC<TweetProps> = ({ tweet }) => {
             <span className="tweet__username"> {user.username} </span>
           </div>
 
-          <div className="tweet__message"> {message} </div>
-          {type === "retweet" && message && (
+          <div className="tweet__message"> {retweet ? retweet : message} </div>
+          {type === "retweet" && retweet && (
             <TweetPreview tweet={tweet}></TweetPreview>
           )}
           <div className="tweet__count-container">

--- a/packages/twitter-ui/src/components/Tweet/Tweet.tsx
+++ b/packages/twitter-ui/src/components/Tweet/Tweet.tsx
@@ -6,6 +6,7 @@ import AutorenewIcon from "@mui/icons-material/Autorenew";
 import { RetweetButton } from "../TweetButtons/RetweetButton";
 import { FavoriteButton } from "../TweetButtons/FavoriteButton";
 import { UserImage } from "../UserImage";
+import TweetPreview from "./TweetPreview";
 
 export interface TweetProps {
   tweet: ITweet;
@@ -31,7 +32,9 @@ const Tweet: React.FC<TweetProps> = ({ tweet }) => {
           </div>
 
           <div className="tweet__message"> {message} </div>
-
+          {type === "retweet" && message && (
+            <TweetPreview tweet={tweet}></TweetPreview>
+          )}
           <div className="tweet__count-container">
             <span title="reply count" className="tweet__reply-count">
               <ModeCommentOutlinedIcon width={"16px"} /> {replyCount}

--- a/packages/twitter-ui/src/components/Tweet/TweetPreview.stories.tsx
+++ b/packages/twitter-ui/src/components/Tweet/TweetPreview.stories.tsx
@@ -1,0 +1,29 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { TweetPreview } from ".";
+import "../../App.scss";
+
+export default {
+  title: "Tweet",
+  component: TweetPreview,
+} as ComponentMeta<typeof TweetPreview>;
+
+const Template: ComponentStory<typeof TweetPreview> = (args) => (
+  <TweetPreview {...args} />
+);
+
+export const NormalTweetPreview = Template.bind({});
+
+NormalTweetPreview.args = {
+  tweet: {
+    id: 1,
+    user: {
+      fullName: "Christoper Francisco",
+      username: "@christopher",
+    },
+    message: "I like coding",
+    favoriteCount: 3,
+    replyCount: 2,
+    retweetCount: 1,
+    type: "default",
+  },
+};

--- a/packages/twitter-ui/src/components/Tweet/TweetPreview.tsx
+++ b/packages/twitter-ui/src/components/Tweet/TweetPreview.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import getUserInitials from "../../utils/getUserInitials";
+import { UserImage } from "../UserImage";
+import type { TweetProps } from "./Tweet";
+
+const TweetPreview: React.FC<TweetProps> = ({ tweet: { user, message } }) => {
+  return (
+    <div className="tweet-preview">
+      <div className="tweet-preview__user-container">
+        <UserImage size={"small"}> {getUserInitials(user.fullName)} </UserImage>
+        <div className="tweet-preview__full-name"> {user.fullName} </div>
+        <span className="tweet-preview__username"> {user.username} </span>
+      </div>
+      <div className="tweet-preview__message"> {message} </div>
+    </div>
+  );
+};
+
+export default TweetPreview;

--- a/packages/twitter-ui/src/components/Tweet/index.ts
+++ b/packages/twitter-ui/src/components/Tweet/index.ts
@@ -1,1 +1,2 @@
 export { default as Tweet } from "./Tweet";
+export { default as TweetPreview } from "./TweetPreview";

--- a/packages/twitter-ui/src/components/TweetButtons/RetweetButton/RetweetButton.tsx
+++ b/packages/twitter-ui/src/components/TweetButtons/RetweetButton/RetweetButton.tsx
@@ -1,31 +1,32 @@
 import React, { useState } from "react";
 import AutorenewIcon from "@mui/icons-material/Autorenew";
-
+import { RetweetModal } from "../../Modal";
 import type { TweetProps } from "../../Tweet/Tweet";
-import { useTweets } from "../../../hooks/useTweets";
 
 const RetweetCount: React.FC<TweetProps> = ({ tweet }) => {
-  const { addRetweet } = useTweets();
-  const [isAlreadyRetweeted, setIsAlreadyRetweeted] = useState<boolean>(false);
+  const [isOpen, setIsOpen] = useState(false);
 
   const handleRetweetClick = () => {
-    addRetweet(tweet);
-    setIsAlreadyRetweeted(true);
+    setIsOpen(true);
   };
+
   return (
-    <span
-      title="retweet count"
-      onClick={() => handleRetweetClick()}
-      className="tweet__retweet-count"
-    >
-      <AutorenewIcon
-        width={"18px"}
-        style={{
-          fill: isAlreadyRetweeted || tweet.type === "retweet" ? "green" : "",
-        }}
-      />{" "}
-      {tweet.retweetCount}
-    </span>
+    <>
+      <span
+        title="retweet count"
+        onClick={() => handleRetweetClick()}
+        className="tweet__retweet-count"
+      >
+        <AutorenewIcon
+          width={"18px"}
+          style={{
+            fill: tweet.type === "retweet" ? "green" : "",
+          }}
+        />{" "}
+        {tweet.retweetCount}
+      </span>
+      <RetweetModal tweet={tweet} isOpen={isOpen} setIsOpen={setIsOpen} />
+    </>
   );
 };
 

--- a/packages/twitter-ui/src/components/TweetTextArea/TweetTextArea.stories.tsx
+++ b/packages/twitter-ui/src/components/TweetTextArea/TweetTextArea.stories.tsx
@@ -1,6 +1,6 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import "../../App.scss";
-import { TweetTextArea } from ".";
+import TweetTextArea from ".";
 
 export default {
   title: "Tweet Text Area",
@@ -12,3 +12,10 @@ const Template: ComponentStory<typeof TweetTextArea> = (args) => (
 );
 
 export const TweetTextAreaNormal = Template.bind({});
+
+TweetTextAreaNormal.args = {
+  handleChange: () => {},
+  name: "Normal tweet text area",
+  label: "What you are thinking today?",
+  value: "",
+};

--- a/packages/twitter-ui/src/components/TweetTextArea/TweetTextArea.tsx
+++ b/packages/twitter-ui/src/components/TweetTextArea/TweetTextArea.tsx
@@ -26,7 +26,6 @@ const TweetTextArea: React.FC<TweetTextAreaProps> = ({
         name={name}
         value={value}
         onChange={handleChange}
-        required
         rows={3}
         cols={40}
       />

--- a/packages/twitter-ui/src/components/TweetTextArea/TweetTextArea.tsx
+++ b/packages/twitter-ui/src/components/TweetTextArea/TweetTextArea.tsx
@@ -1,74 +1,38 @@
 import React from "react";
-import getUserInitials from "../../utils/getUserInitials";
-import { useState } from "react";
-import { useTweets } from "../../hooks/useTweets";
-import { UserImage } from "../UserImage";
+import TextareaAutosize from "react-textarea-autosize";
 
-const newTweetMarkup = {
-  user: {
-    fullName: "Christopher Francisco",
-    username: "@christopher",
-  },
-  favoriteCount: 0,
-  retweetCount: 0,
-  replyCount: 0,
-  type: "default",
-} as const;
+interface TweetTextAreaProps {
+  name: string;
+  label: string;
+  handleChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  value: string;
+  minRows?: number;
+}
 
-const TweetTextArea: React.FC = () => {
-  const [tweetText, setTweetText] = useState("");
-  const { tweets, addTweet } = useTweets();
-
-  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setTweetText(e.target.value);
-  };
-
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    addTweet({
-      ...newTweetMarkup,
-      id: tweets.length + 1,
-      message: tweetText,
-    });
-    cleanAfterTweet();
-  };
-
-  const cleanAfterTweet = () => {
-    setTweetText("");
-  };
-
+const TweetTextArea: React.FC<TweetTextAreaProps> = ({
+  name,
+  label,
+  handleChange,
+  value,
+  minRows = 3,
+}) => {
   return (
-    <div className="tweet-text-area">
-      <div className="tweet-text-area__main-container">
-        <UserImage size="medium">
-          {" "}
-          {getUserInitials(newTweetMarkup.user.fullName)}{" "}
-        </UserImage>
-        <form
-          className="tweet-text-area__form-container"
-          onSubmit={handleSubmit}
-        >
-          <textarea
-            className="tweet-text-area__text-box"
-            name="tweet-text-area"
-            value={tweetText}
-            onChange={handleChange}
-            id="tweet-text-area"
-            required
-            rows={3}
-            cols={40}
-          />
-          <label
-            className="tweet-text-area__text-box__label"
-            htmlFor="tweet-text-area"
-          >
-            What are you thinking today?
-          </label>
-          <button type="submit" className="primary-button">
-            Tweet
-          </button>
-        </form>
-      </div>
+    <div className="text-box__container">
+      <TextareaAutosize
+        id={name}
+        minRows={minRows}
+        maxRows={4}
+        className="text-box"
+        name={name}
+        value={value}
+        onChange={handleChange}
+        required
+        rows={3}
+        cols={40}
+      />
+      <label className="text-box__label" htmlFor={name}>
+        {label}
+      </label>
     </div>
   );
 };

--- a/packages/twitter-ui/src/components/TweetTextArea/TweetTextArea.tsx
+++ b/packages/twitter-ui/src/components/TweetTextArea/TweetTextArea.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import getUserInitials from "../../utils/getUserInitials";
 import { useState } from "react";
 import { useTweets } from "../../hooks/useTweets";
+import { UserImage } from "../UserImage";
 
 const newTweetMarkup = {
   user: {
@@ -39,7 +40,10 @@ const TweetTextArea: React.FC = () => {
   return (
     <div className="tweet-text-area">
       <div className="tweet-text-area__main-container">
-        <figure> {getUserInitials(newTweetMarkup.user.fullName)} </figure>
+        <UserImage size="medium">
+          {" "}
+          {getUserInitials(newTweetMarkup.user.fullName)}{" "}
+        </UserImage>
         <form
           className="tweet-text-area__form-container"
           onSubmit={handleSubmit}

--- a/packages/twitter-ui/src/components/TweetTextArea/index.ts
+++ b/packages/twitter-ui/src/components/TweetTextArea/index.ts
@@ -1,1 +1,1 @@
-export { default as TweetTextArea } from "./TweetTextArea";
+export { default } from "./TweetTextArea";

--- a/packages/twitter-ui/src/components/UserImage/UserImage.stories.tsx
+++ b/packages/twitter-ui/src/components/UserImage/UserImage.stories.tsx
@@ -1,0 +1,31 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { UserImage } from ".";
+import "../../App.scss";
+
+export default {
+  title: "User Image",
+  component: UserImage,
+  argTypes: { onClick: { action: "You just retweeted this tweet!" } },
+} as ComponentMeta<typeof UserImage>;
+
+const Template: ComponentStory<typeof UserImage> = (args) => (
+  <UserImage {...args} children={"J G"} />
+);
+
+export const SmallUserImage = Template.bind({});
+
+SmallUserImage.args = {
+  size: "small",
+};
+
+export const MediumUserImage = Template.bind({});
+
+MediumUserImage.args = {
+  size: "medium",
+};
+
+export const LargeUserImage = Template.bind({});
+
+LargeUserImage.args = {
+  size: "large",
+};

--- a/packages/twitter-ui/src/components/UserImage/UserImage.stories.tsx
+++ b/packages/twitter-ui/src/components/UserImage/UserImage.stories.tsx
@@ -5,7 +5,6 @@ import "../../App.scss";
 export default {
   title: "User Image",
   component: UserImage,
-  argTypes: { onClick: { action: "You just retweeted this tweet!" } },
 } as ComponentMeta<typeof UserImage>;
 
 const Template: ComponentStory<typeof UserImage> = (args) => (

--- a/packages/twitter-ui/src/components/UserImage/UserImage.tsx
+++ b/packages/twitter-ui/src/components/UserImage/UserImage.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+interface UserImageProps {
+  size: "small" | "medium" | "large";
+  children: React.ReactNode;
+}
+
+const UserImage: React.FC<UserImageProps> = ({ size = "medium", children }) => {
+  return (
+    <figure className={`user-image user-image--${size}`}> {children} </figure>
+  );
+};
+
+export default UserImage;

--- a/packages/twitter-ui/src/components/UserImage/index.ts
+++ b/packages/twitter-ui/src/components/UserImage/index.ts
@@ -1,0 +1,1 @@
+export { default as UserImage } from "./UserImage";

--- a/packages/twitter-ui/src/components/__tests__/NewTweetForm.tsx
+++ b/packages/twitter-ui/src/components/__tests__/NewTweetForm.tsx
@@ -2,12 +2,12 @@ import { render, screen, waitFor } from "@testing-library/react";
 import user from "@testing-library/user-event";
 import { TweetContextProvider } from "../../context/TweetContext";
 import { TweetsFeed } from "../TweetsFeed";
-import TweetTextArea from "../TweetTextArea/TweetTextArea";
+import { NewTweetForm } from "../Form";
 
-function renderTweetTextArea() {
+function renderNewTweetForm() {
   return render(
     <TweetContextProvider>
-      <TweetTextArea />
+      <NewTweetForm />
     </TweetContextProvider>
   );
 }
@@ -15,17 +15,17 @@ function renderTweetTextArea() {
 const TweetsFeedWithTextArea = () => (
   <TweetContextProvider>
     <div>
-      <TweetTextArea />
+      <NewTweetForm />
       <TweetsFeed />
     </div>
   </TweetContextProvider>
 );
 
-function renderTweetTextAreaAndTweetsFeed() {
+function renderNewTweetFormAndTweetsFeed() {
   return render(<TweetsFeedWithTextArea />);
 }
 test("should change text in the text area", () => {
-  renderTweetTextArea();
+  renderNewTweetForm();
   const textArea = screen.getByLabelText(/what are you thinking today?/i);
   user.type(textArea, "My first tweet");
 
@@ -34,7 +34,7 @@ test("should change text in the text area", () => {
 });
 
 test("should add a tweet from textbox", async () => {
-  renderTweetTextAreaAndTweetsFeed();
+  renderNewTweetFormAndTweetsFeed();
 
   const textArea = screen.getByLabelText(/what are you thinking today?/i);
   const button = screen.getByRole("button", {

--- a/packages/twitter-ui/src/hooks/useTweets.ts
+++ b/packages/twitter-ui/src/hooks/useTweets.ts
@@ -35,10 +35,7 @@ export function useTweets() {
   };
 
   const addRetweet = (tweet: ITweet) => {
-    setTweets([
-      { ...tweet, id: tweets.length + 1, retweetId: tweet.id, type: "retweet" },
-      ...tweets,
-    ]);
+    setTweets([{ ...tweet, id: tweet.id, type: "retweet" }, ...tweets]);
   };
   return {
     tweets,

--- a/packages/twitter-ui/src/hooks/useTweets.ts
+++ b/packages/twitter-ui/src/hooks/useTweets.ts
@@ -35,7 +35,10 @@ export function useTweets() {
   };
 
   const addRetweet = (tweet: ITweet) => {
-    setTweets([{ ...tweet, id: tweet.id, type: "retweet" }, ...tweets]);
+    setTweets([
+      { ...tweet, id: tweets.length + 1, retweetId: tweet.id, type: "retweet" },
+      ...tweets,
+    ]);
   };
   return {
     tweets,

--- a/packages/twitter-ui/src/types/tweet.ts
+++ b/packages/twitter-ui/src/types/tweet.ts
@@ -7,5 +7,6 @@ export interface ITweet {
   favoriteCount: number;
   replyCount: number;
   retweetCount: number;
+  retweetId?: number;
   type: "default" | "retweet";
 }

--- a/packages/twitter-ui/src/types/tweet.ts
+++ b/packages/twitter-ui/src/types/tweet.ts
@@ -7,6 +7,6 @@ export interface ITweet {
   favoriteCount: number;
   replyCount: number;
   retweetCount: number;
-  retweetId?: number;
   type: "default" | "retweet";
+  retweet?: string;
 }


### PR DESCRIPTION
In this PR: 
* Add a new modal to add text to a retweet (if you do not enter text in the modal the retweet will have no text) and update our tweet model
* Abstract our component button
* Abstract forms into different components (for now we have two: NewTweetForm and RetweetForm)

Observations
Our current retweet feature works like this:
* If a retweet holds no text, it will display a simple message: "You retweeted"
* If a retweet holds text, it will display the current text and below the tweet is a retweet for.

This resolves: #30 