### PR TITLE
chore: remove mocking in components' tests

### DIFF
--- a/packages/twitter-ui/src/features/new-tweet/NewTweetForm.test.tsx
+++ b/packages/twitter-ui/src/features/new-tweet/NewTweetForm.test.tsx
@@ -2,23 +2,15 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import NewTweetForm from "./NewTweetForm";
 import { customTweetContextRender } from "../../utils/test-utils";
-import { ITweet } from "../../types/tweet";
+import { TweetsFeed } from "../tweet-feed";
 
 test("should add a tweet from textbox", async () => {
-  let tweetsFeed: ITweet[] = [];
-
-  const addTweetImplementation = (tweet: ITweet) => {
-    tweetsFeed = [tweet, ...tweetsFeed];
-  };
-
-  const providerProps = {
-    tweets: tweetsFeed,
-    addTweet: jest.fn(addTweetImplementation),
-  };
-
-  customTweetContextRender(<NewTweetForm />, {
-    providerProps,
-  });
+  customTweetContextRender(
+    <>
+      <NewTweetForm />
+      <TweetsFeed />
+    </>
+  );
 
   const textArea = screen.getByLabelText(/what are you thinking today?/i);
   const button = screen.getByRole("button", {
@@ -28,6 +20,6 @@ test("should add a tweet from textbox", async () => {
   userEvent.type(textArea, "New tweet from textbox");
   userEvent.click(button);
 
-  expect(tweetsFeed).toHaveLength(1);
-  expect(providerProps.addTweet).toHaveBeenCalled();
+  const tweetsFeed = screen.getAllByTestId("tweet");
+  expect(tweetsFeed).toHaveLength(4);
 });

--- a/packages/twitter-ui/src/features/retweet/retweet-button/RetweetButton.test.tsx
+++ b/packages/twitter-ui/src/features/retweet/retweet-button/RetweetButton.test.tsx
@@ -1,25 +1,23 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import {
-  customTweetContextRender,
-  dummyTweet,
-} from "../../../utils/test-utils";
-import RetweetButton from "./RetweetButton";
+import { customTweetContextRender } from "../../../utils/test-utils";
+import { TweetsFeed } from "../../tweet-feed";
 
-it("should open Tweet Menu", async () => {
-  /* all the props here are dummy objects */
-  customTweetContextRender(<RetweetButton tweet={dummyTweet} />, {
-    providerProps: { addRetweet: jest.fn() },
-  });
+it("should retweet without text", async () => {
+  customTweetContextRender(
+    <>
+      <TweetsFeed />
+    </>
+  );
 
-  const tweetButton = screen.getByTitle(/retweet/i);
-
+  // Find the first tweet, get and the retweet button of that tweet.
+  const tweetButton = screen.getAllByTitle(/retweet/i)[0];
   userEvent.click(tweetButton);
 
-  const retweetWithoutQuoteOption = await screen.findByText(/retweet/i);
+  // Select retweet without quote option
+  const tweetWithoutQuoteOption = await screen.findByText(/retweet/i);
+  userEvent.click(tweetWithoutQuoteOption);
 
-  userEvent.click(retweetWithoutQuoteOption);
-
-  expect(screen.getByText(/retweet/i)).toBeInTheDocument();
-  expect(screen.getByText(/quote tweet/i)).toBeInTheDocument();
+  expect(screen.getAllByTestId("tweet")).toHaveLength(4);
+  expect(screen.getByText(/you retweeted/i)).toBeInTheDocument();
 });

--- a/packages/twitter-ui/src/features/retweet/retweet-form/RetweetForm.test.tsx
+++ b/packages/twitter-ui/src/features/retweet/retweet-form/RetweetForm.test.tsx
@@ -1,29 +1,22 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { ITweet } from "../../../types/tweet";
-import {
-  customTweetContextRender,
-  dummyTweet as tweetToRetweet,
-} from "../../../utils/test-utils";
+import { tweetsData } from "../../../tweetsData";
+import { customTweetContextRender } from "../../../utils/test-utils";
+import { TweetsFeed } from "../../tweet-feed";
 import RetweetForm from "./RetweetForm";
 
 it("should retweet with text", () => {
-  let tweetsFeed: ITweet[] = [];
+  customTweetContextRender(
+    <>
+      <RetweetForm tweet={tweetsData[0]} />
+      <TweetsFeed />
+    </>
+  );
 
-  const addRetweetWithQuoteImplementation = (tweet: ITweet) => {
-    tweetsFeed = [
-      { ...tweet, type: "retweet", retweet: "I'm quoting a retweet" },
-      ...tweetsFeed,
-    ];
-  };
+  const RETWEET_QUOTE = "I'm quoting this retweet";
 
-  const providerProps = {
-    addRetweet: jest.fn(addRetweetWithQuoteImplementation),
-  };
-
-  customTweetContextRender(<RetweetForm tweet={tweetToRetweet} />, {
-    providerProps: providerProps,
-  });
+  const form = screen.getByLabelText(/add a comment/i);
+  userEvent.type(form, RETWEET_QUOTE);
 
   const retweetButton = screen.getByRole("button", {
     name: /tweet/i,
@@ -31,8 +24,8 @@ it("should retweet with text", () => {
 
   userEvent.click(retweetButton);
 
-  expect(providerProps.addRetweet).toHaveBeenCalled();
-  expect(providerProps.addRetweet).toHaveBeenCalledWith(tweetToRetweet);
-  expect(tweetsFeed[0].type).toBe("retweet");
-  expect(tweetsFeed[0].retweet).toBeTruthy();
+  const tweetsFeed = screen.getAllByTestId("tweet");
+
+  expect(tweetsFeed).toHaveLength(4);
+  expect(screen.getByText(RETWEET_QUOTE)).toBeInTheDocument();
 });

--- a/packages/twitter-ui/src/features/retweet/retweet-form/RetweetForm.tsx
+++ b/packages/twitter-ui/src/features/retweet/retweet-form/RetweetForm.tsx
@@ -21,14 +21,11 @@ const RetweetForm: React.FC<RetweetFormProps> = ({ tweet }) => {
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (retweetText) {
-      addRetweet({
-        ...tweet,
-        retweet: retweetText,
-      });
-      return;
-    }
-    addRetweet(tweet);
+    addRetweet({
+      ...tweet,
+      retweet: retweetText,
+    });
+    setRetweetText("");
   };
 
   return (

--- a/packages/twitter-ui/src/features/retweet/retweet-menu/RetweetOptionsMenu.test.tsx
+++ b/packages/twitter-ui/src/features/retweet/retweet-menu/RetweetOptionsMenu.test.tsx
@@ -1,32 +1,11 @@
 import { screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { ITweet } from "../../../types/tweet";
-import {
-  customTweetContextRender,
-  dummyTweet,
-} from "../../../utils/test-utils";
+import { tweetsData } from "../../../tweetsData";
+import { customTweetContextRender } from "../../../utils/test-utils";
 import RetweetOptionsMenu from "./RetweetOptionsMenu";
 
 it("should retweet without text", async () => {
-  let tweetsFeed = [dummyTweet];
+  customTweetContextRender(<RetweetOptionsMenu tweet={tweetsData[0]} />);
 
-  const addRetweetImplementation = (tweet: ITweet) => {
-    tweetsFeed = [{ ...tweet, type: "retweet" }, ...tweetsFeed];
-  };
-
-  const providerProps = {
-    addRetweet: jest.fn(addRetweetImplementation),
-  };
-
-  customTweetContextRender(<RetweetOptionsMenu tweet={dummyTweet} />, {
-    providerProps: providerProps,
-  });
-
-  const retweetButton = await screen.findByText(/retweet/i);
-
-  userEvent.click(retweetButton);
-
-  expect(providerProps.addRetweet).toHaveBeenCalled();
-  expect(providerProps.addRetweet).toHaveBeenCalledWith(dummyTweet);
-  expect(tweetsFeed[0].type).toBe("retweet");
+  expect(screen.getByText(/retweet/i)).toBeInTheDocument();
+  expect(screen.getByText(/quote tweet/i)).toBeInTheDocument();
 });

--- a/packages/twitter-ui/src/features/tweet-feed/TweetsFeed.test.tsx
+++ b/packages/twitter-ui/src/features/tweet-feed/TweetsFeed.test.tsx
@@ -1,11 +1,9 @@
 import { screen } from "@testing-library/react";
 import TweetsFeed from "./TweetsFeed";
-import { customTweetContextRender, dummyTweet } from "../../utils/test-utils";
+import { customTweetContextRender } from "../../utils/test-utils";
 
 test("should render a list of tweets", () => {
-  customTweetContextRender(<TweetsFeed />, {
-    providerProps: { tweets: Array(3).fill(dummyTweet) },
-  });
+  customTweetContextRender(<TweetsFeed />);
   const tweets = screen.getAllByTestId("tweet");
 
   expect(tweets).toHaveLength(3);

--- a/packages/twitter-ui/src/features/tweet/Tweet.test.tsx
+++ b/packages/twitter-ui/src/features/tweet/Tweet.test.tsx
@@ -1,12 +1,13 @@
 import { screen } from "@testing-library/react";
 import Tweet from "./Tweet";
-import { customTweetContextRender, dummyTweet } from "../../utils/test-utils";
+import { customTweetContextRender } from "../../utils/test-utils";
 import getUserInitials from "../../utils/getUserInitials";
+import { tweetsData } from "../../tweetsData";
 
 it("should render a tweet with mock data", () => {
-  customTweetContextRender(<Tweet tweet={dummyTweet} />, {
-    providerProps: { tweets: [] },
-  });
+  const dummyTweet = tweetsData[0];
+
+  customTweetContextRender(<Tweet tweet={dummyTweet} />);
   //counts
   expect(screen.getByTitle(/favorite count/)).toBeInTheDocument();
   expect(screen.getByTitle(/reply count/)).toBeInTheDocument();

--- a/packages/twitter-ui/src/features/tweet/favorite-button/FavoriteButton.test.tsx
+++ b/packages/twitter-ui/src/features/tweet/favorite-button/FavoriteButton.test.tsx
@@ -1,40 +1,15 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import {
-  customTweetContextRender,
-  dummyTweet,
-} from "../../../utils/test-utils";
+import { tweetsData } from "../../../tweetsData";
+import { customTweetContextRender } from "../../../utils/test-utils";
 import FavoriteButton from "./FavoriteButton";
 
 it("should call increment favorite and decrement favorite", async () => {
-  const incrementFavoriteImplementation = (id: number) => {
-    const toIncrement = [dummyTweet].find((tweet) => tweet.id === id);
-    if (toIncrement) toIncrement.favoriteCount++;
-  };
-
-  const decrementFavoriteImplementation = (id: number) => {
-    const toDecrement = [dummyTweet].find((tweet) => tweet.id === id);
-    if (toDecrement) toDecrement.favoriteCount--;
-  };
-
-  const providerProps = {
-    incrementFavorite: jest.fn(incrementFavoriteImplementation),
-    decrementFavorite: jest.fn(decrementFavoriteImplementation),
-  };
-
-  customTweetContextRender(<FavoriteButton tweet={dummyTweet} />, {
-    providerProps: providerProps,
-  });
+  customTweetContextRender(<FavoriteButton tweet={tweetsData[0]} />);
 
   const favoriteButton = screen.getByTitle(/favorite count/i);
 
   userEvent.click(favoriteButton);
 
-  expect(providerProps.incrementFavorite).toHaveBeenCalled();
-  expect(providerProps.incrementFavorite).toHaveBeenCalledWith(dummyTweet.id);
-
-  userEvent.click(favoriteButton);
-
-  expect(providerProps.incrementFavorite).toHaveBeenCalledWith(dummyTweet.id);
-  expect(providerProps.decrementFavorite).toHaveBeenCalled();
+  expect(screen.getByTitle(/favorite count/i)).toHaveTextContent("3");
 });

--- a/packages/twitter-ui/src/features/tweet/favorite-button/FavoriteButton.tsx
+++ b/packages/twitter-ui/src/features/tweet/favorite-button/FavoriteButton.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import FavoriteBorderOutlinedIcon from "@mui/icons-material/FavoriteBorderOutlined";
 import { useTweets } from "../../../context/TweetContext";
@@ -7,12 +7,16 @@ import { ITweet } from "../../../types/tweet";
 const FavoriteCount: React.FC<{ tweet: ITweet }> = ({
   tweet: { id, favoriteCount },
 }) => {
-  const [isAlreadyFavorite, setIsAlreadyFavorite] = useState<boolean>(false);
+  const [shouldIncrementFavorite, setShouldIncrementFavorite] =
+    useState<boolean>(false);
   const { incrementFavorite, decrementFavorite } = useTweets();
 
+  useEffect(() => {
+    shouldIncrementFavorite ? incrementFavorite(id) : decrementFavorite(id);
+  }, [shouldIncrementFavorite]);
+
   const handleFavoriteClick = () => {
-    setIsAlreadyFavorite((prev) => !prev);
-    isAlreadyFavorite ? decrementFavorite(id) : incrementFavorite(id);
+    setShouldIncrementFavorite((prev) => !prev);
   };
 
   return (
@@ -23,7 +27,7 @@ const FavoriteCount: React.FC<{ tweet: ITweet }> = ({
     >
       <FavoriteBorderOutlinedIcon
         style={{
-          fill: isAlreadyFavorite ? "red" : "",
+          fill: shouldIncrementFavorite ? "red" : "",
         }}
         width={"18px"}
       />

--- a/packages/twitter-ui/src/utils/test-utils.tsx
+++ b/packages/twitter-ui/src/utils/test-utils.tsx
@@ -1,34 +1,10 @@
 import React from "react";
 import { render, RenderOptions } from "@testing-library/react";
-import { TweetContext, TweetContextValues } from "../context/TweetContext";
-import { ITweet } from "../types/tweet";
+import {
+  TweetContextProvider,
+  TweetContextValues,
+} from "../context/TweetContext";
 
-interface CustomRenderTweetOptions {
-  providerProps?: Partial<TweetContextValues>;
-  renderOptions?: RenderOptions;
-}
-
-export const customTweetContextRender = (
-  ui: React.ReactElement,
-  { providerProps, renderOptions }: CustomRenderTweetOptions = {}
-) => {
-  return render(
-    <TweetContext.Provider value={providerProps as TweetContextValues}>
-      {ui}
-    </TweetContext.Provider>,
-    renderOptions
-  );
-};
-
-export const dummyTweet: ITweet = {
-  id: 1,
-  favoriteCount: 0,
-  retweetCount: 0,
-  replyCount: 0,
-  message: "This is a dummy tweet",
-  type: "default",
-  user: {
-    username: "@christopher",
-    fullName: "Christopher Francisco",
-  },
+export const customTweetContextRender = (ui: React.ReactElement) => {
+  return render(<TweetContextProvider>{ui}</TweetContextProvider>);
 };


### PR DESCRIPTION
This PR removes the use of mocking in the components' tests. The reason is the test should resemble as much as possible the usage of the end user with our application, so we leverage the state of our components instead of mocking it